### PR TITLE
Component init: selectors can now match several elements

### DIFF
--- a/src/scripts/index.es6
+++ b/src/scripts/index.es6
@@ -26,7 +26,18 @@ var init = (component) => {
 		if(DEBUG) console.time('\tcomponent: ' + component.name)
 
 		var Component = components[component.name] // class
-		var placement = (typeof component.place == 'string') ? document.querySelector(component.place) : component.place // DOM element
+
+		var placement
+		if (typeof component.place == 'string') {
+			placement = document.querySelectorAll(component.place)
+
+			if (placement.length == 1) {
+				placement = placement[0]
+			}
+		} else {
+			placement = component.place // DOM element
+		}
+
 		var instance = new Component(placement, component.data || {}) // new instance
 
 		instances.push(instance)


### PR DESCRIPTION
Sometimes it is nice to initialize a component on several elements that may be scattered everywhere across the DOM. For instance, if we have a component that makes links pointing to anchors scroll smoothly, it is nice to be able to give such links a common class and then simply initialize the component on all of them.

This change is not completely backwards compatible, though in the vast majority of cases it should be fine.