### PR TITLE
Nib: don't do autoprefixer's job…

### DIFF
--- a/src/styles/index.styl
+++ b/src/styles/index.styl
@@ -1,6 +1,12 @@
 
 // ## Mixins
 // http://visionmedia.github.io/nib/
+
+// These variables prevent nib from trying to do autoprefixer's job with regards to flexbox (it generates things like
+// "display: box;", which is what the autoprefixer should do). Using this gets rid of autoprefixer's complaints.
+flex-version = flex
+support-for-ie = false
+vendor-prefixes = official
 @import 'nib'
 
 // ## Settings and variables


### PR DESCRIPTION
This gets rid of the `autoprefixer: /home/[…]/index.css:123:3: You should write display: flex by final spec instead of display: box` messages in `mango dev` and `mango build`.