### PR TITLE
Change event handler context to the handler component [BC break]

### DIFF
--- a/src/scripts/components/component.es6
+++ b/src/scripts/components/component.es6
@@ -48,7 +48,6 @@ module.exports = class Component {
 	 * Assign event handlers from this.listeners property
 	 */
 	attachListeners() {
-		let self = this
 		let listeners = this.listeners
 
 		for (let event in listeners) {
@@ -63,17 +62,14 @@ module.exports = class Component {
 			}
 
 			/**
-			 * Handler called when an event occured
+			 * Handler called when an event occurred
 			 *
 			 * @callback Component~eventHandler
 			 * @param {object} event - an event object
-			 * @param {Component} self - current instance
 			 * @param {Object} data - optional data passed with event
 			 * @this {Element} - an element that caught the event
 			 */
-			let listener = function (event, data) {
-				callback.call(this, event, self, data)
-			}
+			let listener = $.proxy(callback, this)
 
 			if (selector) {
 				this.$el.on(type, selector, listener)

--- a/src/scripts/components/example.es6
+++ b/src/scripts/components/example.es6
@@ -20,9 +20,9 @@ module.exports = class Example extends Component {
 		}
 	}
 
-	handleClick(e, self) {
+	handleClick(e, data) {
 		e.preventDefault()
-		alert(self.data)
+		alert(this.data)
 	}
 
 }


### PR DESCRIPTION
Na Darujme jsme tuhle změnu udělali dávno, protože to odpovídalo use case ‒ referenci na komponetnu člověk potřebuje daleko častěji než `event.target` (počítal jsem to), což je podle mě o dost důležitější než věrnost tradiční podobě event handlerů. Mimo jiné to s sebou nese i lepší podporu v IDE, které si s `this` poradí daleko lépe než se `self`. K targetu se nyní člověk může dostat výhradně pomocí `e.target`.

Je to ale, pravda, do určité míry věc názoru, a především BC break.

Jinak, separátní otázka, vadí užití `.bind`? Resp. podporujeme vůbec ještě IE 9?