### PR TITLE
SW: disable for now

### DIFF
--- a/mango.yaml
+++ b/mango.yaml
@@ -6,7 +6,7 @@ styles:
   - src/styles/print.styl
 scripts:
   - src/scripts/index.es6
-  - src/serviceWorker.es6
+  #- src/serviceWorker.es6
 images:
   - src/images/**/*.{jpg,png}
 sprites:

--- a/src/scripts/index.es6
+++ b/src/scripts/index.es6
@@ -1,4 +1,4 @@
-require('./utils/swRegister')
+//require('./utils/swRegister')
 
 const jQueryFallbackProvider = require('./utils/jQueryFallbackProvider')
 const componentsHandler = require('./componentsHandler')


### PR DESCRIPTION
Pardon. Ten service worker se ještě neměl dostat do masteru. Měli jsem s @Cactucs okolo toho diskuzi v https://github.com/manGoweb/mango-cli-example/pull/12, což je PR, který byl označen jako `invalid`, aby ho právě nikdo nemergnul.

Budeš muset unregister provést ručně v developer tools.

![image](https://cloud.githubusercontent.com/assets/1045362/23022193/e0c28fdc-f44f-11e6-8211-8fdf148cc401.png)

Každopádně ten SW je už teď funkční. Pro invalidaci cache je potřeba změnit `const CACHE_NAME = 'v1'` na jiný string. Nedoporučuji ho však používat. Už vzniká nová verze, která například tu invalidaci bude dělat sama na základě `BUILDSTAMP`. https://github.com/manGoweb/mango-cli-example/tree/pr/pwa