### PR TITLE
Mandate manually set component names

### DIFF
--- a/src/scripts/componentHandler.ts
+++ b/src/scripts/componentHandler.ts
@@ -8,7 +8,7 @@ export default (components: Array<ComponentConstructor<any>>, initializerName: C
 
 	for (let i = 0, length = components.length; i < length; i++) {
 		const constructor = components[i]
-		const name = constructor.componentName || constructor.name
+		const name = constructor.componentName
 
 		componentsByName[name] = constructor
 	}

--- a/src/scripts/components/Component.ts
+++ b/src/scripts/components/Component.ts
@@ -1,7 +1,7 @@
 import matchesSelector from '../utils/matchesSelector'
 
 interface NamedComponent {
-	componentName?: string
+	componentName: string
 }
 
 export type ComponentConstructor<D> = NamedComponent & (new (element: HTMLElement, data: D) => Component<D>)

--- a/src/scripts/components/Emitter.ts
+++ b/src/scripts/components/Emitter.ts
@@ -17,6 +17,8 @@ interface EmitterData {
  */
 export default class Emitter extends Component<EmitterData> {
 
+	static componentName = 'Emitter'
+
 	events: Events = []
 
 	getListeners = (): EventListeners => [

--- a/src/scripts/components/Example.ts
+++ b/src/scripts/components/Example.ts
@@ -8,8 +8,7 @@ interface ExampleData {
 
 export default class Example extends Component<ExampleData> {
 
-	// Optionally declare this to use a different name than the class name, in this case `Example`
-	// static componentName = 'MyFancyExample'
+	static componentName = 'Example'
 
 	getListeners = (): EventListeners => [
 		['click', this.handleClick],

--- a/src/scripts/components/Shapes.ts
+++ b/src/scripts/components/Shapes.ts
@@ -11,6 +11,8 @@ interface ShapesData {
  */
 export default class Shapes extends Component<ShapesData> {
 
+	static componentName = 'Shapes'
+
 	init() {
 		document.implementation.hasFeature('http://www.w3.org/TR/SVG11/feature#BasicStructure', '1.1') && this.injectSprite()
 	}


### PR DESCRIPTION
Using `.name` doesn't survive minification, and so current `master` is broken. To address this, this pull request mandates components to declare `static componentName`. While this is a concession, I do believe it is still better to keep the name by the component as opposed to many (distant) "index.ts"-like entry files.