### PR TITLE
Shapes: js not needed

### DIFF
--- a/src/scripts/components/ShapesIE.ts
+++ b/src/scripts/components/ShapesIE.ts
@@ -1,19 +1,23 @@
 import { Component } from '@mangoweb/scripts-base'
 
-interface ShapesData {
+interface ShapesIEData {
 	url: string
 }
 
 /**
- * Shapes component class
+ * ShapesIE component class (Internet Explorer fallback)
  *
  * - injects SVG sprite into body
  */
-export default class Shapes extends Component<ShapesData> {
+export default class ShapesIE extends Component<ShapesIEData> {
 
-	static componentName = 'Shapes'
+	static componentName = 'ShapesIE'
 
 	init() {
+		if (window.navigator.userAgent.indexOf('MSIE ') < 0 && !navigator.userAgent.match(/Trident.*rv\:11\./)) {
+			return
+		}
+
 		document.implementation.hasFeature('http://www.w3.org/TR/SVG11/feature#BasicStructure', '1.1') && this.injectSprite()
 	}
 
@@ -34,7 +38,8 @@ export default class Shapes extends Component<ShapesData> {
 			if (el) {
 				body.insertBefore(el, body.firstChild)
 			}
-		}).catch(() => {
+		}).catch((error) => {
+			console.error(error)
 			setTimeout(() => this.injectSprite(), 1e4)
 		})
 	}

--- a/src/scripts/components/ShapesIE.ts
+++ b/src/scripts/components/ShapesIE.ts
@@ -18,7 +18,7 @@ export default class ShapesIE extends Component<ShapesIEData> {
 			return
 		}
 
-		document.implementation.hasFeature('http://www.w3.org/TR/SVG11/feature#BasicStructure', '1.1') && this.injectSprite()
+		this.injectSprite()
 	}
 
 	injectSprite(): void {

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -3,11 +3,11 @@ import { initializeComponents } from '@mangoweb/scripts-base'
 import './plugins'
 
 import Example from './components/Example'
-import Shapes from './components/Shapes'
+import ShapesIE from './components/ShapesIE'
 
 
 // Sort the components alphabetically…
 initializeComponents([
 	Example,
-	Shapes,
-], 'initComponents')
+	ShapesIE,
+])

--- a/src/sprites/plus.svg
+++ b/src/sprites/plus.svg
@@ -1,3 +1,3 @@
 <svg height="21" width="21" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 21 21">
-	<path fill="#266db2" fill-rule="evenodd" d="M9 9H1c-.6 0-1 .4-1 1v1c0 .6.5 1 1 1h8v8c0 .6.4 1 1 1h1c.6 0 1-.4 1-1v-8h8c.6 0 1-.4 1-1v-1c0-.6-.4-1-1-1h-8V1c0-.6-.4-1-1-1h-1c-.6 0-1 .5-1 1v8zm0 0"/>
+	<path fill="currentColor" fill-rule="evenodd" d="M9 9H1c-.6 0-1 .4-1 1v1c0 .6.5 1 1 1h8v8c0 .6.4 1 1 1h1c.6 0 1-.4 1-1v-8h8c.6 0 1-.4 1-1v-1c0-.6-.4-1-1-1h-8V1c0-.6-.4-1-1-1h-1c-.6 0-1 .5-1 1v8zm0 0"/>
 </svg>

--- a/src/styles/parts/shape.sass
+++ b/src/styles/parts/shape.sass
@@ -11,9 +11,7 @@
 
 	// Shapes default dimensions
 	&-plus
-		+size(20px)
-		stroke: #000
-		fill: #000
+		+size(em(21px))
 
 
 	// ... here comes other shape dimensions

--- a/src/templates/layouts/default.pug
+++ b/src/templates/layouts/default.pug
@@ -30,7 +30,7 @@ html(lang=manifest.lang)
 		// Queue of JS components to initialize
 		script.
 			initComponents = [
-				{ name: 'Shapes', data: { url: '#{assetPath}/sprites/shapes.svg' } }
+				{ name: 'ShapesIE', data: { url: '#{assetPath}/sprites/shapes.svg' } }
 			]
 
 		//- Application init

--- a/src/templates/mixins/shape.pug
+++ b/src/templates/mixins/shape.pug
@@ -5,4 +5,7 @@ mixin shape(name, title)
 		if title
 			title= title
 
-		use(xlink:href='#shape-' + name)
+		use(xlink:href=`${assetPath}/sprites/shapes.svg#shape-${name}`)
+
+		//- IE fallback
+		use(xlink:href=`#shape-${name}`)


### PR DESCRIPTION
Nové nastavení je rychlejší, protože spuštění stažení shapes nečeká na vykonání javascriptu a zároveň dává více informací browseru o tom, co jsou shapes za typ souboru, takže je může lépe cachovat.

(IE celé url v `xlink:href` nepodporuje, takže pro něj se dál používají staré shapes na základě detekce podle user agentu.)